### PR TITLE
quick fix for doctrine storage

### DIFF
--- a/Pair/Storage/DoctrineStorage.php
+++ b/Pair/Storage/DoctrineStorage.php
@@ -79,6 +79,7 @@ class DoctrineStorage implements StorageInterface
         }
 
         $this->objectManager->flush();
+        $this->objectManager->clear();
         
         $this->ratioList = $ratioList;
     }


### PR DESCRIPTION
when you have a lot of currencies this script uses more then 1024MB RAM !!! This is a quick fix but a better fix is updating instead of removing and creating
