### PR TITLE
Fix when using multiple entity managers.

### DIFF
--- a/DependencyInjection/Compiler/StorageCompilerPass.php
+++ b/DependencyInjection/Compiler/StorageCompilerPass.php
@@ -20,7 +20,7 @@ class StorageCompilerPass implements CompilerPassInterface
             }
             
             $storageDoctrineDefinition = new Definition('Tbbc\MoneyBundle\Pair\Storage\DoctrineStorage', array(
-                new Reference('doctrine.orm.default_entity_manager'),
+                new Reference('doctrine.orm.entity_manager'),
                 $container->getParameter('tbbc_money.reference_currency')
             ));
             


### PR DESCRIPTION
As per doctrine 2.4 default entity manager is referenced by doctrine.orm.entity_manager.
