### PR TITLE
Better error management in YahooFinanceRatioProvider

### DIFF
--- a/Pair/RatioProvider/YahooFinanceRatioProvider.php
+++ b/Pair/RatioProvider/YahooFinanceRatioProvider.php
@@ -35,11 +35,36 @@ class YahooFinanceRatioProvider implements RatioProviderInterface
             );
         }
 
-        $endpoint = $this->getEndpoint($baseCurrency, $currency);
-        $responseContent = file_get_contents($endpoint);
+        $responseContent = $this->executeQuery($this->getEndpoint($baseCurrency, $currency));
         $ratio = $this->getRatioFromResponse($responseContent);
 
         return $ratio;
+    }
+
+    /**
+     * Executes the query to the API endpoint.
+     *
+     * @param string $endpoint Endpoint's URI
+     *
+     * @return string The response content
+     *
+     * @throws MoneyException if the query has failed or the response status is not 200
+     */
+    protected function executeQuery($endpoint)
+    {
+        $ch = curl_init($endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        $responseContent = curl_exec($ch);
+        $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($responseContent === false || $httpStatus != 200) {
+            throw new MoneyException('Could not execute YahooFinanceRatioProvider query to endpoint '.$endpoint);
+        }
+
+        curl_close($ch);
+
+        return $responseContent;
     }
 
     /**
@@ -61,6 +86,8 @@ class YahooFinanceRatioProvider implements RatioProviderInterface
      * @param string $response The json response of the YahooFinance Api
      *
      * @return float The current exchange rate between currencies
+     *
+     * @throws MoneyException If no rate can be extracted from the response
      */
     protected function getRatioFromResponse($response)
     {
@@ -70,6 +97,10 @@ class YahooFinanceRatioProvider implements RatioProviderInterface
             ->results
             ->rate
             ->Rate;
+        if ($rate == 'N/A') {
+            $pair = $content->query->results->rate->id;
+            throw new MoneyException('YahooFinanceApi does not have an exchange rate for '.$pair);
+        }
         $ratio = (float) $rate;
 
         return $ratio;

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
+        "ext-curl" : "*",
         "symfony/framework-bundle": "~2.1",
         "mathiasverraes/money": "1.2.*",
         "symfony/form": "~2.1",


### PR DESCRIPTION
Use curl for requesting the Yahoo finance API for throwing Exceptions if the query went wrong.