### PR TITLE
Add requiresSQLCommentHint to Money Doctrine type, fix for issue #31

### DIFF
--- a/Type/MoneyType.php
+++ b/Type/MoneyType.php
@@ -25,7 +25,12 @@ class MoneyType extends Type
     {
         return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
- 
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if (is_null($value)) {


### PR DESCRIPTION
Fix for schema update issue #31
Doctrine detects is as a varchar type without requiresSQLCommentHint.

Tested, fixes the issue for me.