### PR TITLE
Fix Symfony2.7 deprecation notices for form types

### DIFF
--- a/Form/Type/CurrencyType.php
+++ b/Form/Type/CurrencyType.php
@@ -5,6 +5,7 @@ namespace Tbbc\MoneyBundle\Form\Type;
 use Tbbc\MoneyBundle\Form\DataTransformer\CurrencyToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
@@ -47,20 +48,22 @@ class CurrencyType
     /**
      * @inheritdoc
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array('reference_currency', 'currency_choices'));
         $resolver->setDefaults(array(
             'reference_currency' => $this->referenceCurrencyCode,
             'currency_choices' => $this->currencyCodeList
         ));
-        $resolver->setAllowedTypes(array(
-            'reference_currency' => array('string'),
-            'currency_choices' => array('array')
-        ));
-        $resolver->setAllowedValues(array(
-            'reference_currency' => $this->currencyCodeList
-        ));
+        $resolver->setAllowedTypes('reference_currency', 'string');
+        $resolver->setAllowedTypes('currency_choices', 'array');
+        $resolver->setAllowedValues('reference_currency', $this->currencyCodeList);
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
 
     /**

--- a/Form/Type/MoneyType.php
+++ b/Form/Type/MoneyType.php
@@ -44,12 +44,12 @@ class MoneyType
             ->setDefaults(array(
                 'currency_type' => 'tbbc_currency',
             ))
-            ->setAllowedTypes(array(
-                'currency_type' => array(
+            ->setAllowedTypes(
+                'currency_type', array(
                     'string',
                     'Tbbc\MoneyBundle\Form\Type\CurrencyType',
-                ),
-            ))
+                )
+            )
         ;
     }
 

--- a/Form/Type/MoneyType.php
+++ b/Form/Type/MoneyType.php
@@ -5,6 +5,7 @@ namespace Tbbc\MoneyBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Tbbc\MoneyBundle\Form\DataTransformer\MoneyToArrayTransformer;
 
@@ -37,7 +38,7 @@ class MoneyType
             );
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults(array(
@@ -50,6 +51,12 @@ class MoneyType
                 ),
             ))
         ;
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
 
     /**


### PR DESCRIPTION
this updates MoneyType and FormType so they match Symfony 2.7 requirements and don't throw deprecation notices.