### PR TITLE
Add the capability to define a specific currency for the simple money form type

### DIFF
--- a/Form/DataTransformer/SimpleMoneyToArrayTransformer.php
+++ b/Form/DataTransformer/SimpleMoneyToArrayTransformer.php
@@ -10,19 +10,16 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  */
 class SimpleMoneyToArrayTransformer extends MoneyToArrayTransformer
 {
-    /** @var  PairManagerInterface */
-    protected $pairManager;
+    protected $currency;
 
     /**
      * SimpleMoneyToArrayTransformer constructor.
      *
-     * @param PairManagerInterface $pairManager
-     * @param int                  $decimals
+     * @param int $decimals
      */
-    public function __construct(PairManagerInterface $pairManager, $decimals)
+    public function __construct($decimals)
     {
         parent::__construct($decimals);
-        $this->pairManager = $pairManager;
     }
 
     /**
@@ -45,9 +42,17 @@ class SimpleMoneyToArrayTransformer extends MoneyToArrayTransformer
     public function reverseTransform($value)
     {
         if (is_array($value)) {
-            $value["tbbc_currency"] = new Currency($this->pairManager->getReferenceCurrencyCode());
+            $value["tbbc_currency"] = new Currency($this->currency);
         }
 
         return parent::reverseTransform($value);
+    }
+
+    /**
+     * @param string $currency
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
     }
 }

--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -17,8 +17,9 @@
             <tag name="form.type" alias="tbbc_money" />
         </service>
         <service id="tbbc_money.form_type.simple_money" class="%tbbc_money.form_type.simple_money.class%">
-            <argument type="service" id="tbbc_money.pair_manager"/>
             <argument>%tbbc_money.decimals%</argument>
+            <argument>%tbbc_money.currencies%</argument>
+            <argument>%tbbc_money.reference_currency%</argument>
             <tag name="form.type" alias="tbbc_simple_money" />
         </service>
     </services>

--- a/Tests/Form/Type/SimpleMoneyTypeTest.php
+++ b/Tests/Form/Type/SimpleMoneyTypeTest.php
@@ -74,6 +74,9 @@ class SimpleMoneyTypeTest
         //This is probably not ideal, but I'm not sure how to set up the pair manager
         // with different decimals for different tests in Symfony 3.0
         $decimals = 2;
+        $currencies = array('EUR', 'USD');
+        $referenceCurrency = 'EUR';
+
         if($this->getName() === "testBindValidDecimals")
             $decimals = 3;
 
@@ -86,9 +89,19 @@ class SimpleMoneyTypeTest
 
         return array(
             new PreloadedExtension(
-                array(new SimpleMoneyType($this->pairManager, $decimals)), array()
+                array(new SimpleMoneyType($decimals, $currencies, $referenceCurrency)), array()
             )
         );
+    }
+
+    public function testOverrideCurrency()
+    {
+        \Locale::setDefault("fr_FR");
+        $form = $this->factory->create($this->simpleMoneyTypeClass, null, ["currency" => "USD"]);
+        $form->submit(array(
+            "tbbc_amount" => '1 252,5'
+        ));
+        $this->assertEquals(Money::USD(125250), $form->getData());
     }
 
 }


### PR DESCRIPTION
Before the modification, the simple money form type used only the default currency.
Yet, in specific case (platform with multiple currencies, for example), it can be useful to be able to choose which currency should be used.

With this PR, it is now possible.
