### PR TITLE
[Symfony 3.0] Allow 3.0 dom crawler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/form": "~2.1",
         "symfony/twig-bundle": "~2.1",
         "symfony/console": "~2.1",
-        "symfony/dom-crawler": "~2.0"
+        "symfony/dom-crawler": "~2.0|~3.0"
     },
     "require-dev": {
         "symfony/class-loader": "~2.1",


### PR DESCRIPTION
I wanted to use the 3.0 dom crawler but couldn't because of this package, I forked and updated the composer.json to allow for the new 3.0 version. Looking at the code it's only used in the ratio fetcher, and only the filter method is used (which hasn't changed looking at the changelog).

https://github.com/symfony/dom-crawler/blob/master/CHANGELOG.md

Please merge so I can delete fork and use the original.

Thanks!