### PR TITLE
Set the precision of MoneyToLocalizedStringTransformer

### DIFF
--- a/Form/DataTransformer/MoneyToArrayTransformer.php
+++ b/Form/DataTransformer/MoneyToArrayTransformer.php
@@ -21,7 +21,7 @@ class MoneyToArrayTransformer implements DataTransformerInterface
     public function __construct($decimals = 2)
     {
         $this->decimals = (int)$decimals;
-        $this->sfTransformer = new MoneyToLocalizedStringTransformer(null, null, null, pow(10, $this->decimals));
+        $this->sfTransformer = new MoneyToLocalizedStringTransformer($decimals, null, null, pow(10, $this->decimals));
     }
 
     /**


### PR DESCRIPTION
set the precision of MoneyToLocalizedStringTransformer with $decimals, this fixes a rounding bug (because the symfony transformer uses a precision parameter. 
Current behaviour is when you are on a 3 decimal setting for example and you transform a 100,105 float, you get 100,11.