### PR TITLE
Fixed phpunit tests (were broken because of doctrine dbal changes)

### DIFF
--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -12,8 +12,9 @@ framework:
 
 doctrine:
     dbal:
-        driver:   'pdo_sqlite'
+        driver:   "pdo_sqlite"
         memory:   true
+        path:     ":memory:"
     orm:
         entity_managers:
             default:


### PR DESCRIPTION
Doctrine team added requirement so that either `path` or `dbname` parameter should be set when opening a connection. But for tests we use in-memory sqlite, so neither of those was provided and it threw and exception.

Setting database path as `path: ":memory:"` solves the problem.