### PR TITLE
Added static ratio provider (helpful for tests)

### DIFF
--- a/Pair/RatioProvider/StaticRatioProvider.php
+++ b/Pair/RatioProvider/StaticRatioProvider.php
@@ -1,0 +1,54 @@
+<?php
+namespace Tbbc\MoneyBundle\Pair\RatioProvider;
+
+use Tbbc\MoneyBundle\MoneyException;
+use Tbbc\MoneyBundle\Pair\RatioProviderInterface;
+
+/**
+ * Static ratio provider
+ *
+ * @author Pavel Dubinin <geekdevs@gmail.com>
+ * @package Tbbc\MoneyBundle\Pair\RatioProvider
+ */
+class StaticRatioProvider implements RatioProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $ratios = [];
+
+    /**
+     * @param string $referenceCurrencyCode
+     * @param string $currencyCode
+     * @param float $ratio
+     */
+    public function setRatio($referenceCurrencyCode, $currencyCode, $ratio)
+    {
+        $pair = $this->getPairCode($referenceCurrencyCode, $currencyCode);
+        $this->ratios[$pair] = $ratio;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchRatio($referenceCurrencyCode, $currencyCode)
+    {
+        $pair = $this->getPairCode($referenceCurrencyCode, $currencyCode);
+
+        if (!isset($this->ratios[$pair])) {
+            throw new MoneyException('StaticRatioProvider does not have an exchange rate for '.$pair);
+        }
+
+        return $this->ratios[$pair];
+    }
+
+    /**
+     * @param $referenceCurrencyCode
+     * @param $currencyCode
+     * @return string
+     */
+    private function getPairCode($referenceCurrencyCode, $currencyCode)
+    {
+        return $referenceCurrencyCode . '-' . $currencyCode;
+    }
+}

--- a/Pair/RatioProvider/StaticRatioProvider.php
+++ b/Pair/RatioProvider/StaticRatioProvider.php
@@ -15,7 +15,7 @@ class StaticRatioProvider implements RatioProviderInterface
     /**
      * @var array
      */
-    private $ratios = [];
+    private $ratios = array();
 
     /**
      * @param string $referenceCurrencyCode

--- a/Tests/Pair/RatioProvider/StaticRatioProviderTest.php
+++ b/Tests/Pair/RatioProvider/StaticRatioProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tbbc\MoneyBundle\Tests\Pair\Storage;
+
+use Tbbc\MoneyBundle\Pair\RatioProvider\StaticRatioProvider;
+
+/**
+ * @author Pavel Dubinin <geekdevs@gmail.com>
+ * @group  manager
+ */
+class StaticRatioProviderTest extends AbstractRatioProviderTest
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getRatioProvider()
+    {
+        return new StaticRatioProvider();
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        /**
+         * @var StaticRatioProvider $ratioProvider
+         */
+        $ratioProvider = $this->ratioProvider;
+        $ratios = $this->getRatiosToTest();
+
+        foreach ($ratios as $idx=>$ratioData) {
+            $ratio = $this->randomRatio($ratioData['ratio_min'], $ratioData['ratio_max'], $idx);
+
+            $ratioProvider->setRatio(
+                $ratioData['reference'],
+                $ratioData['currency'],
+                $ratio
+            );
+        }
+    }
+
+    public function testSetRatio()
+    {
+        $ratioProvider = $this->getRatioProvider();
+
+        $ratioProvider->setRatio('EUR', 'USD', 1.23);
+        $this->assertSame(1.23, $ratioProvider->fetchRatio('EUR', 'USD'));
+
+        $ratioProvider->setRatio('EUR', 'USD', 1.67);
+        $this->assertSame(1.67, $ratioProvider->fetchRatio('EUR', 'USD'));
+    }
+
+    /**
+     * @param float $ratioMin
+     * @param float $ratioMax
+     * @param int $seed
+     *
+     * @return float
+     */
+    private function randomRatio($ratioMin, $ratioMax, $seed)
+    {
+        $precision = 100;
+        mt_srand($seed); //so that values are same across tests
+        return mt_rand($ratioMin*$precision, $ratioMax*$precision) / $precision;
+    }
+}


### PR DESCRIPTION
As described here https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/pull/45#issuecomment-173834262

Tests were not stable because PairManagerTest::testRatioProvider() checks yahoo finance to get exchange rates. It checks it twice in the same test and values can differ between calls.

I have created `StaticRatioProvider` which would basically fetch whatever ratios you provide to it with `StaticRatioProvider::setRatio()`. This is helpful for making tests more stable as results do not change across calls and there's no need to ping yahoo each time since that test tests how `PairManager` works only (yahoo is already tested separately).


