### PR TITLE
Update SimpleMoneyType.php

### DIFF
--- a/Form/Type/SimpleMoneyType.php
+++ b/Form/Type/SimpleMoneyType.php
@@ -31,7 +31,7 @@ class SimpleMoneyType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('tbbc_amount', new TextType())
+            ->add('tbbc_amount', new TextType(), array('label'=>false))
             ->addModelTransformer(
                 new SimpleMoneyToArrayTransformer($this->pairManager, $this->decimals)
             );


### PR DESCRIPTION
The SimpleMoneyType form adds the label "tbbc_amount" when used.  So something like this

```
		$form = $this->createFormBuilder()
			->add('cost', \Tbbc\MoneyBundle\Form\Type\SimpleMoneyType::class)
```

creates a field with 2 labels, "Cost" and "tbbc_amount". I can't picture an occasion when "tbbc_amount" would be the preferred label so I've set that label to false