### PR TITLE
Fixed travis to actually test different versions of symfony correctly, added phpunit bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,34 @@ php:
   - 5.4
   - 5.5
   - 5.6
+#  - 7.0 (conflicts with dbunit)
 
-before_script:
+env:
+  - SYMFONY_VERSION=2.3.* #php >=5.3.3
+  - SYMFONY_VERSION=2.7.* #php >=5.3.9
+  - SYMFONY_VERSION=2.8.* #php >=5.3.9
+  #- SYMFONY_VERSION=3.0.* #php >=5.5.9
+
+before_install:
+  - export SYMFONY_DEPRECATIONS_HELPER=weak #set this to "strict" to make build fail on deprecation messages
   - composer self-update
-  - composer install --dev --prefer-source
+  - mv composer.json composer.json.bck
+  - sed 's/${env:SYMFONY_VERSION}/'$SYMFONY_VERSION'/g' composer-template.json > composer.json #replace composer dependencies with actual symfony version
 
-script: ./vendor/bin/phpunit --coverage-text
+install:
+  - composer update --prefer-dist --no-interaction
+
+after_install:
+  - mv composer.json.bck composer.json
+
+script: phpunit --coverage-text
+
+matrix:
+  exclude:
+    - php: 5.3
+      env: SYMFONY_VERSION=3.0.*
+    - php: 5.4
+      env: SYMFONY_VERSION=3.0.*
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-#  - 7.0 (conflicts with dbunit)
+  - 7.0
 
 env:
   - SYMFONY_VERSION=2.3.* #php >=5.3.3
@@ -25,7 +25,7 @@ install:
 after_install:
   - mv composer.json.bck composer.json
 
-script: phpunit --coverage-text
+script: vendor/bin/phpunit --coverage-text
 
 matrix:
   exclude:

--- a/composer-template.json
+++ b/composer-template.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.3.3",
         "ext-curl" : "*",
         "symfony/framework-bundle": "${env:SYMFONY_VERSION}",
         "mathiasverraes/money": "1.2.*",
@@ -33,8 +33,8 @@
         "ext-sqlite3": "*",
         "doctrine/doctrine-bundle": "~1.1",
         "doctrine/orm": "~2.3",
-        "phpunit/phpunit": "~3.7",
-        "phpunit/dbunit": "~1.3",
+        "phpunit/phpunit": "~4|~5",
+        "phpunit/dbunit": "~1.4",
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {

--- a/composer-template.json
+++ b/composer-template.json
@@ -1,0 +1,48 @@
+{
+    "name": "tbbc/money-bundle",
+    "type": "symfony-bundle",
+    "description": "This is a Symfony2 bundle that integrates the php money library from Mathias Verraes (Fowler pattern): https://github.com/mathiasverraes/money.",
+    "keywords": ["money", "currency", "fowler", "conversion"],
+    "homepage": "https://github.com/TheBigBrainsCompany/TbbcMoneyBundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Philippe Le Van",
+            "homepage": "https://twitter.com/plv"
+        },
+        {
+            "name": "Sebastien Lefebvre"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "ext-curl" : "*",
+        "symfony/framework-bundle": "${env:SYMFONY_VERSION}",
+        "mathiasverraes/money": "1.2.*",
+        "symfony/form": "${env:SYMFONY_VERSION}",
+        "symfony/twig-bundle": "${env:SYMFONY_VERSION}",
+        "symfony/console": "${env:SYMFONY_VERSION}",
+        "symfony/dom-crawler": "${env:SYMFONY_VERSION}"
+    },
+    "require-dev": {
+        "symfony/class-loader": "${env:SYMFONY_VERSION}",
+        "symfony/yaml": "${env:SYMFONY_VERSION}",
+        "symfony/finder": "${env:SYMFONY_VERSION}",
+        "symfony/browser-kit": "${env:SYMFONY_VERSION}",
+        "beberlei/DoctrineExtensions": "0.3.*",
+        "ext-sqlite3": "*",
+        "doctrine/doctrine-bundle": "~1.1",
+        "doctrine/orm": "~2.3",
+        "phpunit/phpunit": "~3.7",
+        "phpunit/dbunit": "~1.3",
+        "symfony/phpunit-bridge": "~2.7|~3.0"
+    },
+    "suggest": {
+        "doctrine/doctrine-bundle": "~1.1",
+        "doctrine/orm": "~2.3"
+    },
+    "autoload": {
+        "psr-0": { "Tbbc\\MoneyBundle": "" }
+    },
+    "target-dir": "Tbbc/MoneyBundle"
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.3.3",
         "ext-curl" : "*",
         "symfony/framework-bundle": "~2.3",
         "mathiasverraes/money": "1.2.*",
@@ -33,8 +33,9 @@
         "ext-sqlite3": "*",
         "doctrine/doctrine-bundle": "~1.1",
         "doctrine/orm": "~2.3",
-        "phpunit/phpunit": "~3.7",
-        "phpunit/dbunit": "~1.3"
+        "phpunit/phpunit": "~4|~5",
+        "phpunit/dbunit": "~1.4",
+        "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "~1.1",


### PR DESCRIPTION
It happens that we did not actually test various versions of symfony, but rather just switched env variables in travis with no effect (doh!). I fixed that so that each version is tested separately.

To make this work every symfony component dependency needed to be changed into according symfony version depending on what we test. 

Unfortunately composer does not support env variables yet (https://github.com/composer/composer/issues/2036), so I've created `composer-template.json` file for that matter which json would use to replace `${env:SYMFONY_VERSION}` variable with actual version on each build.

I have also added phpunit bridge to watch for deprecation messages. I muted it for now with `SYMFONY_DEPRECATIONS_HELPER=weak` because otherwise all builds are failing. It would however still show how many deprecated errors there are on travis console. We'll need to make it `strict` once current depredations are solved (essential for v.3 migration).