### PR TITLE
Added option to use hard space when formatting a money string

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -87,6 +87,9 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('hard_space')
+                    ->defaultValue(false)
+                ->end()
             ->end()
         ;
     }

--- a/DependencyInjection/TbbcMoneyExtension.php
+++ b/DependencyInjection/TbbcMoneyExtension.php
@@ -40,6 +40,7 @@ class TbbcMoneyExtension extends Extension
             'decimals'  => 'tbbc_money.decimals',
             'enable_pair_history'  => 'tbbc_money.enable_pair_history',
             'ratio_provider'  => 'tbbc_money.ratio_provider',
+            'hard_space' => 'tbbc_money.hard_space',
         ));
         
         $container->setParameter('tbbc_money.pair.storage', $config['storage']);

--- a/Formatter/MoneyFormatter.php
+++ b/Formatter/MoneyFormatter.php
@@ -15,9 +15,12 @@ class MoneyFormatter
 {
     protected $decimals;
 
-    public function __construct($decimals = 2)
+    protected $useHardSpace;
+
+    public function __construct($decimals = 2, $useHardSpace = false)
     {
         $this->decimals = $decimals;
+        $this->useHardSpace = $useHardSpace;
     }
 
     protected function getDefaultNumberFormatter($currencyCode, $locale = null)
@@ -49,7 +52,9 @@ class MoneyFormatter
         if (!($numberFormatter instanceof \NumberFormatter)) {
             $numberFormatter = $this->getDefaultNumberFormatter($money->getCurrency()->getName(), $locale);
         }
-        return $numberFormatter->formatCurrency($this->asFloat($money), $money->getCurrency()->getName());
+        return $this->ensureCorrectSpace(
+            $numberFormatter->formatCurrency($this->asFloat($money), $money->getCurrency()->getName())
+        );
     }
 
     /**
@@ -68,7 +73,7 @@ class MoneyFormatter
         $amount = $this->formatAmount($money, $decPoint, $thousandsSep);
         $price = $amount . " " . $symbol;
 
-        return $price;
+        return $this->ensureCorrectSpace($price);
     }
 
     /**
@@ -86,7 +91,7 @@ class MoneyFormatter
         $amount = $this->asFloat($money);
         $amount = number_format($amount, $this->decimals, $decPoint, $thousandsSep);
 
-        return $amount;
+        return $this->ensureCorrectSpace($amount);
     }
 
     /**
@@ -146,5 +151,20 @@ class MoneyFormatter
     public function getCurrency(Money $money)
     {
         return $money->getCurrency();
+    }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    protected function ensureCorrectSpace($string)
+    {
+        if ($this->useHardSpace) {
+            $softSpace = ' ';
+            $hardSpace = ' ';
+            $string = str_replace($softSpace, $hardSpace, $string);
+        }
+
+        return $string;
     }
 }

--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ in your config.yml, you can :
 
 * select the templating engine to use. By default, only twig is loaded.
 * define the decimals count after a unit (ex : 12.25€ : 2 decimals ; 11.5678€ : 4 decimals)
+* define to use hard space or not. If true the money string will not line break.
 
 ```yaml
 tbbc_money:
@@ -540,6 +541,7 @@ tbbc_money:
     decimals: 2
     enable_pair_history: true
     ratio_provider: tbbc_money.ratio_provider.yahoo_finance
+    hard_space: true
 ```
 
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -40,6 +40,7 @@
         <!-- Formatter -->
         <service id="tbbc_money.formatter.money_formatter" class="%tbbc_money.formatter.money_formatter.class%">
             <argument>%tbbc_money.decimals%</argument>
+            <argument>%tbbc_money.hard_space%</argument>
         </service>
     </services>
 

--- a/Tests/Formatter/MoneyFormatterTest.php
+++ b/Tests/Formatter/MoneyFormatterTest.php
@@ -117,4 +117,12 @@ class MoneyFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Money\Currency', $value);
         $this->assertEquals(new Currency('EUR'), $value);
     }
+
+    public function testUseHardSpace()
+    {
+        $formatter = new MoneyFormatter(2, true);
+        $value = $formatter->formatMoney($this->inputMoney);
+        $this->assertEquals('1 234 567,89 €', $value);
+        $this->assertNotEquals('1 234 567,89 €', $value);
+    }
 }


### PR DESCRIPTION
When stuffing string with amounts in a table it often leads to ugly line breaks. Using a hard space character prevents that.

<img width="249" alt="screenshot 2016-05-07 07 33 00" src="https://cloud.githubusercontent.com/assets/165154/15090427/e7e9b974-1427-11e6-9406-cefb97ed72ff.png">
<img width="282" alt="screenshot 2016-05-07 07 34 01" src="https://cloud.githubusercontent.com/assets/165154/15090428/e7f53650-1427-11e6-8f37-1d09a26089b2.png">
