### PR TITLE
form -> resources is obsolete, use instead  form_themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,8 @@ In your config.yml, add the form fields presentations
 
 ```yaml
 twig:
-    form:
-        resources:
-            - 'TbbcMoneyBundle:Form:fields.html.twig'
+    form_themes:
+        - 'TbbcMoneyBundle:Form:fields.html.twig'
 ```
 
 


### PR DESCRIPTION
Otherwise in symfony3 i got the error described here:

http://stackoverflow.com/questions/35073399/following-manual-instructions-for-bootstrap-3-forms-getting-yml-config-error

> Unrecognized option "form" under "twig"