### PR TITLE
Move doctrine type registration to a compiler pass

### DIFF
--- a/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
@@ -27,7 +27,7 @@ class DoctrineTypeCompilerPass implements CompilerPassInterface
         $typeConfig = $container->getParameter($parameter);
         $typeConfig[MoneyType::NAME] = array(
             'class' => 'Tbbc\MoneyBundle\Type\MoneyType',
-            'commented' => true
+            'commented' => true,
         );
         $container->setParameter($parameter, $typeConfig);
 

--- a/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
@@ -1,0 +1,47 @@
+<?php
+namespace Tbbc\MoneyBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Doctrine\DBAL\Types\Type;
+use Tbbc\MoneyBundle\Type\MoneyType;
+
+/**
+ * Class DoctrineTypeCompilerPass
+ * @package Tbbc\MoneyBundle\DependencyInjection\Compiler
+ */
+class DoctrineTypeCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $parameter = 'doctrine.dbal.connection_factory.types';
+        if (!$container->hasParameter($parameter)) {
+            return;
+        }
+
+        $typeConfig = $container->getParameter($parameter);
+        $typeConfig[MoneyType::NAME] = array(
+            'class' => 'Tbbc\MoneyBundle\Type\MoneyType',
+            'commented' => true
+        );
+        $container->setParameter($parameter, $typeConfig);
+
+        foreach ($container->getServiceIds() as $name) {
+            if (!preg_match('/^doctrine.dbal.\w+_connection$/', $name)) {
+                continue;
+            }
+            $connection = $container->getDefinition($name);
+            $mappingTypes = $connection->getArgument(3);
+            if (isset($mappingTypes[MoneyType::NAME])) {
+                continue;
+            }
+            $mappingTypes[MoneyType::NAME] = MoneyType::NAME;
+            $connection->replaceArgument(3, $mappingTypes);
+        }
+    }
+}

--- a/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
@@ -25,11 +25,13 @@ class DoctrineTypeCompilerPass implements CompilerPassInterface
         }
 
         $typeConfig = $container->getParameter($parameter);
-        $typeConfig[MoneyType::NAME] = array(
-            'class' => 'Tbbc\MoneyBundle\Type\MoneyType',
-            'commented' => true,
-        );
-        $container->setParameter($parameter, $typeConfig);
+        if (!isset($typeConfig[MoneyType::NAME])) {
+            $typeConfig[MoneyType::NAME] = array(
+                'class' => 'Tbbc\MoneyBundle\Type\MoneyType',
+                'commented' => true,
+            );
+            $container->setParameter($parameter, $typeConfig);
+        }
 
         foreach ($container->getServiceIds() as $name) {
             if (!preg_match('/^doctrine.dbal.\w+_connection$/', $name)) {

--- a/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineTypeCompilerPass.php
@@ -33,11 +33,8 @@ class DoctrineTypeCompilerPass implements CompilerPassInterface
             $container->setParameter($parameter, $typeConfig);
         }
 
-        foreach ($container->getServiceIds() as $name) {
-            if (!preg_match('/^doctrine.dbal.\w+_connection$/', $name)) {
-                continue;
-            }
-            $connection = $container->getDefinition($name);
+        foreach ($container->getParameter('doctrine.connections') as $service) {
+            $connection = $container->getDefinition($service);
             $mappingTypes = $connection->getArgument(3);
             if (isset($mappingTypes[MoneyType::NAME])) {
                 continue;

--- a/TbbcMoneyBundle.php
+++ b/TbbcMoneyBundle.php
@@ -3,13 +3,10 @@ namespace Tbbc\MoneyBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
-use Doctrine\DBAL\Types\Type;
-
 use Tbbc\MoneyBundle\DependencyInjection\Compiler\PairHistoryCompilerPass;
 use Tbbc\MoneyBundle\DependencyInjection\Compiler\RatioProviderCompilerPass;
 use Tbbc\MoneyBundle\DependencyInjection\Compiler\StorageCompilerPass;
-use Tbbc\MoneyBundle\Type\MoneyType;
+use Tbbc\MoneyBundle\DependencyInjection\Compiler\DoctrineTypeCompilerPass;
 
 /**
  * Class TbbcMoneyBundle
@@ -27,27 +24,6 @@ class TbbcMoneyBundle extends Bundle
         $container->addCompilerPass(new StorageCompilerPass());
         $container->addCompilerPass(new PairHistoryCompilerPass());
         $container->addCompilerPass(new RatioProviderCompilerPass());
-    }
-
-    /**
-     * Boot
-     */
-    public function boot()
-    {
-        parent::boot();
-
-        if ($this->container->hasParameter('doctrine.entity_managers')) {
-            if (!Type::hasType(MoneyType::NAME)) {
-                Type::addType(MoneyType::NAME, 'Tbbc\MoneyBundle\Type\MoneyType');
-            }
-
-            $entityManagerNameList = $this->container->getParameter('doctrine.entity_managers');
-            foreach ($entityManagerNameList as $entityManagerName) {
-                $em = $this->container->get($entityManagerName);
-                if (!$em->getConnection()->getDatabasePlatform()->hasDoctrineTypeMappingFor(MoneyType::NAME)) {
-                    $em->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapping(MoneyType::NAME, MoneyType::NAME);
-                }
-            }
-        }
+        $container->addCompilerPass(new DoctrineTypeCompilerPass());
     }
 }

--- a/Tests/Fonctionnal/ConfigTest.php
+++ b/Tests/Fonctionnal/ConfigTest.php
@@ -121,7 +121,9 @@ class ConfigTest
         
         $this->assertTrue(Type::hasType(MoneyType::NAME));
         
-        $em = $this->client->getContainer()->get('doctrine')->getManager('default');
-        $this->assertEquals(MoneyType::NAME, $em->getConnection()->getDatabasePlatform()->getDoctrineTypeMapping(MoneyType::NAME));
+        foreach (array('default', 'other') as $name) {
+            $em = $this->client->getContainer()->get('doctrine')->getManager($name);
+            $this->assertEquals(MoneyType::NAME, $em->getConnection()->getDatabasePlatform()->getDoctrineTypeMapping(MoneyType::NAME));
+        }
     }
 }

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -12,10 +12,19 @@ framework:
 
 doctrine:
     dbal:
-        driver:   "pdo_sqlite"
-        memory:   true
-        path:     ":memory:"
+        connections:
+            default:
+                driver:   "pdo_sqlite"
+                memory:   true
+                path:     ":memory:"
+            other:
+                driver:   "pdo_sqlite"
+                memory:   true
+                path:     ":memory:"
+
     orm:
         entity_managers:
             default:
                 auto_mapping: true
+            other:
+                connection: other


### PR DESCRIPTION
Thanks for the great bundle!

I was having an issue clearing the cache when the database wasn't present (e.g. on a CI server):

```
$ ./bin/console cache:clear -v


  [PDOException (2002)]
  SQLSTATE[HY000] [2002] Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)


Exception trace:
 () at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:43
 PDO->__construct() at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:43
 Doctrine\DBAL\Driver\PDOConnection->__construct() at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php:45
 Doctrine\DBAL\Driver\PDOMySql\Driver->connect() at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:360
 Doctrine\DBAL\Connection->connect() at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:429
 Doctrine\DBAL\Connection->getDatabasePlatformVersion() at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:389
 Doctrine\DBAL\Connection->detectDatabasePlatform() at /home/vagrant/web/clients.glynnforrest.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:328
 Doctrine\DBAL\Connection->getDatabasePlatform() at /home/vagrant/code/projects/TbbcMoneyBundle/TbbcMoneyBundle.php:47
 Tbbc\MoneyBundle\TbbcMoneyBundle->boot() at /home/vagrant/web/clients.glynnforrest.com/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:121
 Symfony\Component\HttpKernel\Kernel->boot() at /home/vagrant/web/clients.glynnforrest.com/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:68
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /home/vagrant/web/clients.glynnforrest.com/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:117
 Symfony\Component\Console\Application->run() at /home/vagrant/web/clients.glynnforrest.com/bin/console:25
```

As you can see, the `boot()` method of this bundle fetches each dbal connection, which in turn tries to connect to the database.

I moved this logic to a compiler pass, with the added benefit that this type configuration is no longer done at runtime. This gives a slight speed improvement!