### PR TITLE
Fix parse error on PHP 5.6.36

### DIFF
--- a/Pair/RatioProvider/ECBRatioProvider.php
+++ b/Pair/RatioProvider/ECBRatioProvider.php
@@ -105,9 +105,8 @@ class ECBRatioProvider implements RatioProviderInterface
 
         $pairs = [];
         foreach($xmlObject->Cube->Cube->children() as $rateObject) {
-            $rate     = ((array) $rateObject->attributes())['@attributes']['rate'];
-            $currency = ((array) $rateObject->attributes())['@attributes']['currency'];
-            $pairs[$currency] = $rate;
+            $attributes = (array) $rateObject->attributes();
+            $pairs[$attributes['@attributes']['currency']] = $rate['@attributes']['rate'];
         }
 
         return $pairs;


### PR DESCRIPTION
 PHP Parse error:  syntax error, unexpected '[' in /var/www/vendor/tbbc/money-bundle/Tbbc/MoneyBundle/Pair/RatioProvider/ECBRatioProvider.php on line 108