### PR TITLE
Change url for ECB provider to https as they are redirecting there now.

### DIFF
--- a/Pair/RatioProvider/ECBRatioProvider.php
+++ b/Pair/RatioProvider/ECBRatioProvider.php
@@ -81,7 +81,7 @@ class ECBRatioProvider implements RatioProviderInterface
         //get current exchange rate XML
         $curlHandle = curl_init();
         curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($curlHandle, CURLOPT_URL, "http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml");
+        curl_setopt($curlHandle, CURLOPT_URL, "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml");
         $curlResponse = curl_exec($curlHandle);
         curl_close($curlHandle);
 

--- a/README.md
+++ b/README.md
@@ -410,10 +410,11 @@ class IndexController extends Controller
 
 The ratio provider by default is base on the service 'tbbc_money.ratio_provider.yahoo_finance'
 
-This bundles contains two ratio providers :
+This bundles contains three ratio providers :
 
 * tbbc_money.ratio_provider.yahoo_finance based on the Yahoo finance APIs https://developer.yahoo.com/
 * tbbc_money.ratio_provider.google based on the https://www.google.com/finance/converter service
+* tbbc_money.ratio_provider.ecb based on the data provided here https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 
 You can change the service to use in the config.yml file :
 


### PR DESCRIPTION
Bugfix for the ECB provider. They redirect from http to https now. Also included it in the README.