### PR TITLE
Removed CommandContainerAware in favor of Command.

### DIFF
--- a/Command/RatioFetchCommand.php
+++ b/Command/RatioFetchCommand.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Tbbc\MoneyBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tbbc\MoneyBundle\MoneyException;
@@ -11,8 +12,23 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  * Class RatioFetchCommand
  * @package Tbbc\MoneyBundle\Command
  */
-class RatioFetchCommand extends ContainerAwareCommand
+class RatioFetchCommand extends Command
 {
+
+    /**
+     * @var PairManagerInterface
+     */
+    private $pairManager;
+
+    /**
+     * @param PairManagerInterface $pairManager
+     */
+    public function __construct(PairManagerInterface $pairManager)
+    {
+        parent::__construct();
+        $this->pairManager = $pairManager;
+    }
+
     /**
      * Configure command
      */
@@ -21,23 +37,20 @@ class RatioFetchCommand extends ContainerAwareCommand
         $this
             ->setName('tbbc:money:ratio-fetch')
             ->setHelp('The <info>tbbc:money:ratio-fetch</info> fetch all needed ratio from a external ratio provider')
-            ->setDescription('fetch all needed ratio from a external ratio provider')
-        ;
+            ->setDescription('fetch all needed ratio from a external ratio provider');
     }
 
     /**
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      *
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var PairManagerInterface $pairManager */
-        $pairManager = $this->getContainer()->get('tbbc_money.pair_manager');
         try {
-            $pairManager->saveRatioListFromRatioProvider();
-            $output->writeln('ratio fetched from provider'.PHP_EOL.print_r($pairManager->getRatioList(), true));
+            $this->pairManager->saveRatioListFromRatioProvider();
+            $output->writeln('ratio fetched from provider'.PHP_EOL.print_r($this->pairManager->getRatioList(), true));
         } catch (MoneyException $e) {
             $output->writeln('ERROR during fetch ratio : '.$e->getMessage());
         }

--- a/Command/RatioListCommand.php
+++ b/Command/RatioListCommand.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Tbbc\MoneyBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tbbc\MoneyBundle\Pair\PairManagerInterface;
@@ -10,8 +11,23 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  * Class RatioListCommand
  * @package Tbbc\MoneyBundle\Command
  */
-class RatioListCommand extends ContainerAwareCommand
+class RatioListCommand extends Command
 {
+
+    /**
+     * @var PairManagerInterface
+     */
+    private $pairManager;
+
+    /**
+     * @param PairManagerInterface $pairManager
+     */
+    public function __construct(PairManagerInterface $pairManager)
+    {
+        parent::__construct();
+        $this->pairManager = $pairManager;
+    }
+
     /**
      * Configure command
      */
@@ -20,21 +36,18 @@ class RatioListCommand extends ContainerAwareCommand
         $this
             ->setName('tbbc:money:ratio-list')
             ->setHelp('The <info>tbbc:money:ratio-list</info> display list of registered ratio')
-            ->setDescription('display list of registered ratio')
-        ;
+            ->setDescription('display list of registered ratio');
     }
 
     /**
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      *
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var PairManagerInterface $pairManager */
-        $pairManager = $this->getContainer()->get('tbbc_money.pair_manager');
-        $ratioList = $pairManager->getRatioList();
+        $ratioList = $this->pairManager->getRatioList();
         $output->writeln('Ratio list');
         foreach ($ratioList as $currencyCode => $ratio) {
             $output->writeln($currencyCode.';'.$ratio);

--- a/Command/RatioSaveCommand.php
+++ b/Command/RatioSaveCommand.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Tbbc\MoneyBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,8 +13,23 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  * Class RatioSaveCommand
  * @package Tbbc\MoneyBundle\Command
  */
-class RatioSaveCommand extends ContainerAwareCommand
+class RatioSaveCommand extends Command
 {
+
+    /**
+     * @var PairManagerInterface
+     */
+    private $pairManager;
+
+    /**
+     * @param PairManagerInterface $pairManager
+     */
+    public function __construct(PairManagerInterface $pairManager)
+    {
+        parent::__construct();
+        $this->pairManager = $pairManager;
+    }
+
     /**
      * Configure command
      */
@@ -32,12 +48,11 @@ class RatioSaveCommand extends ContainerAwareCommand
                 'ratio',
                 InputArgument::REQUIRED,
                 'Ratio to the reference currency (ex: 1.2563) ?'
-            )
-        ;
+            );
     }
 
     /**
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      *
      * @return void
@@ -47,10 +62,8 @@ class RatioSaveCommand extends ContainerAwareCommand
         $currencyCode = $input->getArgument('currencyCode');
         $ratio = (float) $input->getArgument('ratio');
 
-        /** @var PairManagerInterface $pairManager */
-        $pairManager = $this->getContainer()->get('tbbc_money.pair_manager');
         try {
-            $pairManager->saveRatio($currencyCode, $ratio);
+            $this->pairManager->saveRatio($currencyCode, $ratio);
             $output->writeln('ratio saved');
         } catch (MoneyException $e) {
             $output->writeln('ERROR : ratio no saved du to error : '.$e->getMessage());

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -55,12 +55,15 @@
 
         <!-- Commands -->
         <service id="tbbc_money.command.ratio_fetch" class="%tbbc_money.command.ratio_fetch.class%">
+            <argument type="service" id="tbbc_money.pair_manager" />
             <tag name="console.command" command="tbbc:money:ratio-fetch" />
         </service>
         <service id="tbbc_money.command.ratio_list" class="%tbbc_money.command.ratio_list.class%">
+            <argument type="service" id="tbbc_money.pair_manager" />
             <tag name="console.command" command="tbbc:money:ratio-list" />
         </service>
         <service id="tbbc_money.command.ratio_save" class="%tbbc_money.command.ratio_save.class%">
+            <argument type="service" id="tbbc_money.pair_manager" />
             <tag name="console.command" command="tbbc:money:ratio-save" />
         </service>
     </services>


### PR DESCRIPTION
The ContainerAwareCommand class has been deprecated, use Symfony\Component\Console\Command\Command with dependency injection instead.