### PR TITLE
Added root name to treebuilder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tbbc_money');
+        $treeBuilder = new TreeBuilder('tbbc_money');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('tbbc_money');
+        }
+
         $this->addCurrencySection($rootNode);
 
         return $treeBuilder;


### PR DESCRIPTION
Deprecated constructing a TreeBuilder without passing root node information

Including a BC for older SF versions