### PR TITLE
Added options so its possible to manipulate the form fields

### DIFF
--- a/Form/Type/CurrencyType.php
+++ b/Form/Type/CurrencyType.php
@@ -38,10 +38,10 @@ class CurrencyType extends AbstractType
         foreach ($options["currency_choices"] as $currencyCode) {
             $choiceList[$currencyCode] = $currencyCode;
         }
-        $builder->add('tbbc_name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+        $builder->add('tbbc_name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array_merge(array(
             "choices" => $choiceList,
             "preferred_choices" => array($options["reference_currency"]),
-        ));
+        ), $options['currency_options']));
         $builder->addModelTransformer(new CurrencyToArrayTransformer());
     }
 
@@ -54,10 +54,12 @@ class CurrencyType extends AbstractType
         $resolver->setDefaults(array(
             'reference_currency' => $this->referenceCurrencyCode,
             'currency_choices' => $this->currencyCodeList,
+            'currency_options' => array(),
         ));
         $resolver->setAllowedTypes('reference_currency', 'string');
         $resolver->setAllowedTypes('currency_choices', 'array');
         $resolver->setAllowedValues('reference_currency', $this->currencyCodeList);
+        $resolver->setAllowedTypes('currency_options', 'array');
     }
 
     /**

--- a/Form/Type/MoneyType.php
+++ b/Form/Type/MoneyType.php
@@ -31,8 +31,8 @@ class MoneyType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('tbbc_amount', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('tbbc_currency', $options['currency_type'])
+            ->add('tbbc_amount', 'Symfony\Component\Form\Extension\Core\Type\TextType', $options['amount_options'])
+            ->add('tbbc_currency', $options['currency_type'], $options['currency_options'])
             ->addModelTransformer(
                 new MoneyToArrayTransformer($this->decimals)
             );
@@ -47,6 +47,8 @@ class MoneyType extends AbstractType
             ->setDefaults(array(
                 'data_class' => null,
                 'currency_type' => 'Tbbc\MoneyBundle\Form\Type\CurrencyType',
+                'amount_options' => array(),
+                'currency_options' => array(),
             ))
             ->setAllowedTypes(
                 'currency_type',
@@ -54,6 +56,14 @@ class MoneyType extends AbstractType
                     'string',
                     'Tbbc\MoneyBundle\Form\Type\CurrencyType',
                 )
+            )
+            ->setAllowedTypes(
+                'amount_options',
+                'array'
+            )
+            ->setAllowedTypes(
+                'currency_options',
+                'array'
             )
         ;
     }

--- a/Form/Type/SimpleMoneyType.php
+++ b/Form/Type/SimpleMoneyType.php
@@ -43,7 +43,7 @@ class SimpleMoneyType extends MoneyType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('tbbc_amount', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('tbbc_amount', 'Symfony\Component\Form\Extension\Core\Type\TextType', $options['amount_options'])
         ;
 
         $transformer = new SimpleMoneyToArrayTransformer($this->decimals);
@@ -69,9 +69,11 @@ class SimpleMoneyType extends MoneyType
     {
         $resolver->setDefaults(array(
             'currency' => $this->referenceCurrencyCode,
+            'amount_options' => array(),
         ));
         $resolver->setAllowedTypes('currency', 'string');
         $resolver->setAllowedValues('currency', $this->currencyCodeList);
+        $resolver->setAllowedTypes('amount_options', 'array');
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -153,6 +153,27 @@ $form = $this->createFormBuilder()
     ->getForm();
 ```
 
+Manipulating the form
+
+With `MoneyType` you can manipulate the form elements with
+
+`amount_options` for the amount field, and `currency_options` for the currency field, fx if you want to change the label.
+
+```php
+$form = $this->createFormBuilder()
+    ->add('price', MoneyType::class, [
+        'data' => Money::EUR(1000), //EUR 10
+        'amount_options' => array(
+            'label' => 'Amount',
+        ),
+        'currency_options' => array(
+            'label' => 'Currency',
+        ),
+    ])
+    ->getForm();
+```
+
+With `CurrencyType` only `currency_options` can be used, and with `SimpleMoneyType` only `amount_options` can be used.
 
 ### Saving Money with Doctrine
 

--- a/Tests/Form/Type/CurrencyTypeTest.php
+++ b/Tests/Form/Type/CurrencyTypeTest.php
@@ -9,6 +9,7 @@ namespace Tbbc\MoneyBundle\Tests\Form\Type;
 use Money\Currency;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tbbc\MoneyBundle\Form\Type\CurrencyType;
 
 class CurrencyTypeTest
@@ -31,6 +32,32 @@ class CurrencyTypeTest
         $formView = $form->createView();
 
         $this->assertEquals("USD", $formView->children["tbbc_name"]->vars["value"]);
+    }
+
+    public function testOptions()
+    {
+        $form = $this->factory->create($this->currencyTypeClass, null, array(
+            'currency_options' => array(
+                'label' => 'currency label',
+            )
+        ));
+
+        $form->setData(new Currency("USD"));
+        $formView = $form->createView();
+
+        $this->assertEquals("USD", $formView->children["tbbc_name"]->vars["value"]);
+    }
+
+    public function testOptionsFailsIfNotValid()
+    {
+        $this->expectException(UndefinedOptionsException::class);
+        $this->expectExceptionMessageRegExp('/this_does_not_exists/');
+
+        $this->factory->create($this->currencyTypeClass, null, array(
+            'currency_options' => array(
+                'this_does_not_exists' => 'currency label',
+            )
+        ));
     }
 
     protected function getExtensions()

--- a/Tests/Form/Type/MoneyTypeTest.php
+++ b/Tests/Form/Type/MoneyTypeTest.php
@@ -9,6 +9,7 @@ namespace Tbbc\MoneyBundle\Tests\Form\Type;
 use Money\Currency;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\FormIntegrationTestCase;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tbbc\MoneyBundle\Form\Type\CurrencyType;
 use Tbbc\MoneyBundle\Form\Type\MoneyType;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -69,6 +70,40 @@ class MoneyTypeTest
         $formView = $form->createView();
 
         $this->assertEquals("1,20", $formView->children["tbbc_amount"]->vars["value"]);
+    }
+
+    public function testOptions()
+    {
+        \Locale::setDefault("fr_FR");
+        $form = $this->factory->create($this->moneyTypeClass, null, array(
+            "currency_type" => $this->currencyTypeClass,
+            "amount_options" => array(
+                'label' => 'Amount',
+            ),
+            "currency_options" => array(
+                'label' => 'Currency',
+            ),
+        ));
+        $form->setData(Money::EUR(120));
+        $formView = $form->createView();
+
+        $this->assertEquals("1,20", $formView->children["tbbc_amount"]->vars["value"]);
+    }
+
+    public function testOptionsFailsIfNotValid()
+    {
+        $this->expectException(UndefinedOptionsException::class);
+        $this->expectExceptionMessageRegExp('/this_does_not_exists/');
+
+        $this->factory->create($this->moneyTypeClass, null, array(
+            "currency_type" => $this->currencyTypeClass,
+            "amount_options" => array(
+                'this_does_not_exists' => 'Amount',
+            ),
+            "currency_options" => array(
+                'label' => 'Currency',
+            ),
+        ));
     }
 
     protected function getExtensions()

--- a/Tests/Form/Type/SimpleMoneyTypeTest.php
+++ b/Tests/Form/Type/SimpleMoneyTypeTest.php
@@ -9,6 +9,7 @@ namespace Tbbc\MoneyBundle\Tests\Form\Type;
 use Money\Currency;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\FormIntegrationTestCase;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Tbbc\MoneyBundle\Form\Type\CurrencyType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Money\Money;
@@ -67,6 +68,32 @@ class SimpleMoneyTypeTest
         $formView = $form->createView();
 
         $this->assertEquals("1,20", $formView->children["tbbc_amount"]->vars["value"]);
+    }
+
+    public function testOptions()
+    {
+        \Locale::setDefault("fr_FR");
+        $form = $this->factory->create($this->simpleMoneyTypeClass, null, array(
+            'amount_options' => array(
+                'label' => 'Amount',
+            ),
+        ));
+        $form->setData(Money::EUR(120));
+        $formView = $form->createView();
+
+        $this->assertEquals("1,20", $formView->children["tbbc_amount"]->vars["value"]);
+    }
+
+    public function testOptionsFailsIfNotValid()
+    {
+        $this->expectException(UndefinedOptionsException::class);
+        $this->expectExceptionMessageRegExp('/this_does_not_exists/');
+
+        $this->factory->create($this->simpleMoneyTypeClass, null, array(
+            'amount_options' => array(
+                'this_does_not_exists' => 'Amount',
+            ),
+        ));
     }
 
     protected function getExtensions()


### PR DESCRIPTION
I was getting a bit annoyed that by fields label were tbbc_amount and tbbc_currency.
So now its possible to change it

With `MoneyType` you can manipulate the form elements with `amount_options` for the amount field, and `currency_options` for the currency field, fx if you want to change the label.

```php
$form = $this->createFormBuilder()
    ->add('price', MoneyType::class, [
        'data' => Money::EUR(1000), //EUR 10
        'amount_options' => array(
            'label' => 'Amount',
        ),
        'currency_options' => array(
            'label' => 'Currency',
        ),
    ])
    ->getForm();
```

With `CurrencyType` only `currency_options` can be used, and with `SimpleMoneyType` only `amount_options` can be used.

Also added to README and added tests