### PR TITLE
Fixed: Deprecated tree builders without root nodes

### DIFF
--- a/Command/RatioFetchCommand.php
+++ b/Command/RatioFetchCommand.php
@@ -13,13 +13,14 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  */
 class RatioFetchCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'tbbc:money:ratio-fetch';
+    
     /**
      * Configure command
      */
     protected function configure()
     {
         $this
-            ->setName('tbbc:money:ratio-fetch')
             ->setHelp('The <info>tbbc:money:ratio-fetch</info> fetch all needed ratio from a external ratio provider')
             ->setDescription('fetch all needed ratio from a external ratio provider')
         ;

--- a/Command/RatioListCommand.php
+++ b/Command/RatioListCommand.php
@@ -12,13 +12,14 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  */
 class RatioListCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'tbbc:money:ratio-list';
+    
     /**
      * Configure command
      */
     protected function configure()
     {
         $this
-            ->setName('tbbc:money:ratio-list')
             ->setHelp('The <info>tbbc:money:ratio-list</info> display list of registered ratio')
             ->setDescription('display list of registered ratio')
         ;

--- a/Command/RatioSaveCommand.php
+++ b/Command/RatioSaveCommand.php
@@ -14,13 +14,14 @@ use Tbbc\MoneyBundle\Pair\PairManagerInterface;
  */
 class RatioSaveCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'tbbc:money:ratio-save';
+    
     /**
      * Configure command
      */
     protected function configure()
     {
         $this
-            ->setName('tbbc:money:ratio-save')
             ->setHelp('The <info>tbbc:money:ratio-save</info> save a currency ratio')
             ->setDescription('save a currency ratio')
             ->addArgument(

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tbbc_money');
+        $treeBuilder = new TreeBuilder('tbbc_money');
+        $rootNode = $treeBuilder->getRootNode();
         $this->addCurrencySection($rootNode);
 
         return $treeBuilder;

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -1,14 +1,10 @@
 {% block tbbc_money_widget %}
-    {% spaceless %}
-        {% for child in form %}
-            {{ form_widget(child) }}
-        {% endfor %}
-    {% endspaceless %}
+    {% for child in form %}
+        {{ form_widget(child) | spaceless }}
+    {% endfor %}
 {% endblock %}
 {% block tbbc_currency_widget %}
-    {% spaceless %}
-        {% for child in form %}
-            {{ form_widget(child) }}
-        {% endfor %}
-    {% endspaceless %}
+    {% for child in form %}
+        {{ form_widget(child) | spaceless }}
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
See https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes