### PR TITLE
Fix deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Tests/app/cache/*
 Tests/app/logs/*
 Tests/coverage/*
 Tests/app/coverage/*
+
+.idea

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('currencies')
                     ->scalarPrototype()->end()
                     ->defaultValue(['EUR', 'USD'])
-                    ->cannotBeEmpty()
+                    ->requiresAtLeastOneElement()
                 ->end()
                 ->scalarNode('reference_currency')
                     ->defaultValue('EUR')

--- a/Pair/PairManager.php
+++ b/Pair/PairManager.php
@@ -103,7 +103,7 @@ class PairManager implements PairManagerInterface, Exchange
             $ratio,
             $savedAt
         );
-        $this->dispatcher->dispatch($event, TbbcMoneyEvents::AFTER_RATIO_SAVE);
+        $this->dispatcher->dispatch(TbbcMoneyEvents::AFTER_RATIO_SAVE, $event);
     }
 
     /**

--- a/Pair/SaveRatioEvent.php
+++ b/Pair/SaveRatioEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tbbc\MoneyBundle\Pair;
 
-use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class SaveRatioEvent


### PR DESCRIPTION
Got this deprecation warning (using Symfony 3.4):

  1x: Using Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty() at path "tbbc_money.currencies" has no effect, consider requiresAtLeastOneElement() instead. In 4.0 both methods will behave the same.

This changes to use `requiresAtLeastOneElement` as the message suggests