### PR TITLE
Add alias for MoneyManager Class

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -34,6 +34,8 @@
             <argument>%tbbc_money.reference_currency%</argument>
             <argument>%tbbc_money.decimals%</argument>
         </service>
+        <service id="%tbbc_money.money_manager.class%" alias="tbbc_money.money_manager" public="false">
+        </service>
         <!-- Storage -->
         <service id="tbbc_money.pair.csv_storage" class="%tbbc_money.pair.csv_storage.class%" public="true">
             <argument>%tbbc_money.pair_manager.ratio_file_name%</argument>


### PR DESCRIPTION
If we want to access to Money Manager with dependency injection, we need to have this alias.

Else, we have this error:
```
argument "$moneyManager" of method "__construct()" references class "Tbbc\MoneyBundle\Money\MoneyManager" but no such service exists. You should maybe alias this class to the existing "tbbc_money.money_manager" service.
```