### PR TITLE
Resolve concurrency issues when fetching ratios from provider

### DIFF
--- a/Pair/PairManager.php
+++ b/Pair/PairManager.php
@@ -103,7 +103,7 @@ class PairManager implements PairManagerInterface, Exchange
             $ratio,
             $savedAt
         );
-        $this->dispatcher->dispatch(TbbcMoneyEvents::AFTER_RATIO_SAVE, $event);
+        $this->dispatcher->dispatch($event, TbbcMoneyEvents::AFTER_RATIO_SAVE);
     }
 
     /**

--- a/Pair/SaveRatioEvent.php
+++ b/Pair/SaveRatioEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tbbc\MoneyBundle\Pair;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class SaveRatioEvent

--- a/Pair/Storage/DoctrineStorage.php
+++ b/Pair/Storage/DoctrineStorage.php
@@ -76,14 +76,17 @@ class DoctrineStorage implements StorageInterface
     {
         $doctrineStorageRatios = $this->entityManager->getRepository('Tbbc\MoneyBundle\Entity\DoctrineStorageRatio')->findAll();
 
-        // first remove all existing ratios
-        foreach ($doctrineStorageRatios as $doctrineStorageRatio) {
-            $this->entityManager->remove($doctrineStorageRatio);
-        }
-        // then add new ones
-        foreach ($ratioList as $currencyCode => $ratio) {
-            $this->entityManager->persist(new DoctrineStorageRatio($currencyCode, $ratio));
-        }
+        // do it all in a transaction to avoid concurrency issue while we insert new ones
+        $this->entityManager->transactional(function($em) use ($doctrineStorageRatios, $ratioList) {
+            // first remove all existing ratios
+            foreach ($doctrineStorageRatios as $doctrineStorageRatio) {
+                $em->remove($doctrineStorageRatio);
+            }
+            // then add new ones
+            foreach ($ratioList as $currencyCode => $ratio) {
+                $em->persist(new DoctrineStorageRatio($currencyCode, $ratio));
+            }
+        });
 
         // flush to database to do remove and insert in one transaction
         $this->entityManager->flush();

--- a/Pair/Storage/DoctrineStorage.php
+++ b/Pair/Storage/DoctrineStorage.php
@@ -76,16 +76,16 @@ class DoctrineStorage implements StorageInterface
     {
         $doctrineStorageRatios = $this->entityManager->getRepository('Tbbc\MoneyBundle\Entity\DoctrineStorageRatio')->findAll();
 
+        // first remove all existing ratios
         foreach ($doctrineStorageRatios as $doctrineStorageRatio) {
             $this->entityManager->remove($doctrineStorageRatio);
         }
-
-        $this->entityManager->flush();
-
+        // then add new ones
         foreach ($ratioList as $currencyCode => $ratio) {
             $this->entityManager->persist(new DoctrineStorageRatio($currencyCode, $ratio));
         }
 
+        // flush to database to do remove and insert in one transaction
         $this->entityManager->flush();
         $this->entityManager->clear();
 

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,10 @@
     "autoload": {
         "psr-4": { "Tbbc\\MoneyBundle\\": "" },
         "exclude-from-classmap": [ "/Tests/" ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     }
 }


### PR DESCRIPTION
This resolves a concurrency issue we have observed when ratios are removed and then inserted again. Instead we now update existing rows.

It also adds compatibility with Symfony 4/5, this branch from me was merged https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/pull/123 with Symfony 3.4 compatibility as merged but it actually breaks symfony 4/5 compatibility that we use now (can only blame myself).

The real solution for that is probably #136, it seems impossible to maintain compatibility with Symfony all of 3/4/5 here, so maybe these changes should not even be merged here, and rather the #136 should be merged for Symfony 5/6 compatibility instead.