### PR TITLE
Fix issue #134

### DIFF
--- a/Pair/PairManager.php
+++ b/Pair/PairManager.php
@@ -103,7 +103,7 @@ class PairManager implements PairManagerInterface, Exchange
             $ratio,
             $savedAt
         );
-        $this->dispatcher->dispatch(TbbcMoneyEvents::AFTER_RATIO_SAVE, $event);
+        $this->dispatcher->dispatch($event, TbbcMoneyEvents::AFTER_RATIO_SAVE);
     }
 
     /**

--- a/Pair/SaveRatioEvent.php
+++ b/Pair/SaveRatioEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tbbc\MoneyBundle\Pair;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class SaveRatioEvent


### PR DESCRIPTION
This fixes the "Class "Symfony\Component\EventDispatcher\Event" not found" exception, that occurs with Symfony 5.3 and later.

This issue was also reported by @potibm #134.