### PR TITLE
Remove Yahoo & Google ratio providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,20 +449,32 @@ class IndexController extends Controller
 
 ### Change the ratio provider
 
-The ratio provider by default is base on the service 'tbbc_money.ratio_provider.ecb'
+The ratio provider by default is base on the service `tbbc_money.ratio_provider.ecb`.
 
-This bundles contains three ratio providers :
+* `tbbc_money.ratio_provider.ecb` ratio provider is based on the data provided here https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
 
-* tbbc_money.ratio_provider.ecb based on the data provided here https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
-* tbbc_money.ratio_provider.yahoo_finance based on the Yahoo finance APIs https://developer.yahoo.com/ (yahoo does not provide this api anymore)
-* tbbc_money.ratio_provider.google based on the https://www.google.com/finance/converter service (google does not provide this api anymore)
+You can write your own ratio provider by creating and custom class that implements the `RatioProviderInterface` interface.
 
-You can change the service to use in the config.yml file :
+```php
+namespace App\Money;
+
+use Tbbc\MoneyBundle\Pair\RatioProviderInterface;
+
+final class YourRatioProviderService implements RatioProviderInterface
+{
+    public function fetchRatio(string $referenceCurrencyCode, string $currencyCode): float
+    {
+        // implement your custom logic here
+    }
+}
+```
+
+You can change the service to use in the `config/packages/tbbc_money.yaml` file :
 
 ```
 tbbc_money:
     [...]
-    ratio_provider: tbbc_money.ratio_provider.google
+    ratio_provider: App\Money\YourRatioProviderService
 ```
 
 ### Additional rate providers from Exchanger

--- a/change-log-6.0-and-versions.md
+++ b/change-log-6.0-and-versions.md
@@ -1,0 +1,17 @@
+Versions from 6.0
+-----------------
+
+### 2023-10-31 : updates for 6.0.0 version
+
+**New features**
+
+**BC breaking changes**
+
+- Drop `YahooFinanceRatioProvider` ratio provider support
+  - Remove `tbbc_money.ratio_provider.yahoo_finance.class` container parameter
+  - Remove `tbbc_money.ratio_provider.yahoo_finance` service definition
+- Drop `GoogleRatioProvider` ratio provider support
+  - Remove `tbbc_money.ratio_provider.google.class` container parameter
+  - Remove `tbbc_money.ratio_provider.google` service definition
+
+**Internal Developer things**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,7 +11,6 @@
         <parameter key="tbbc_money.pair_history_manager.class">Tbbc\MoneyBundle\PairHistory\PairHistoryManager</parameter>
         <parameter key="tbbc_money.pair.csv_storage.class">Tbbc\MoneyBundle\Pair\Storage\CsvStorage</parameter>
         <parameter key="tbbc_money.pair_manager.ratio_file_name">%kernel.project_dir%/../data/tbbc_money/ratio_file_name.csv</parameter>
-        <parameter key="tbbc_money.ratio_provider.google.class">Tbbc\MoneyBundle\Pair\RatioProvider\GoogleRatioProvider</parameter>
         <parameter key="tbbc_money.ratio_provider.ecb.class">Tbbc\MoneyBundle\Pair\RatioProvider\ECBRatioProvider</parameter>
         <parameter key="tbbc_money.formatter.money_formatter.class">Tbbc\MoneyBundle\Formatter\MoneyFormatter</parameter>
 
@@ -41,8 +40,6 @@
             <argument>%tbbc_money.reference_currency%</argument>
         </service>
         <!-- Ratio providers -->
-        <service id="tbbc_money.ratio_provider.google" class="%tbbc_money.ratio_provider.google.class%" public="true">
-        </service>
         <service id="tbbc_money.ratio_provider.ecb" class="%tbbc_money.ratio_provider.ecb.class%">
             <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface"/>
         </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,7 +11,6 @@
         <parameter key="tbbc_money.pair_history_manager.class">Tbbc\MoneyBundle\PairHistory\PairHistoryManager</parameter>
         <parameter key="tbbc_money.pair.csv_storage.class">Tbbc\MoneyBundle\Pair\Storage\CsvStorage</parameter>
         <parameter key="tbbc_money.pair_manager.ratio_file_name">%kernel.project_dir%/../data/tbbc_money/ratio_file_name.csv</parameter>
-        <parameter key="tbbc_money.ratio_provider.yahoo_finance.class">Tbbc\MoneyBundle\Pair\RatioProvider\YahooFinanceRatioProvider</parameter>
         <parameter key="tbbc_money.ratio_provider.google.class">Tbbc\MoneyBundle\Pair\RatioProvider\GoogleRatioProvider</parameter>
         <parameter key="tbbc_money.ratio_provider.ecb.class">Tbbc\MoneyBundle\Pair\RatioProvider\ECBRatioProvider</parameter>
         <parameter key="tbbc_money.formatter.money_formatter.class">Tbbc\MoneyBundle\Formatter\MoneyFormatter</parameter>
@@ -42,8 +41,6 @@
             <argument>%tbbc_money.reference_currency%</argument>
         </service>
         <!-- Ratio providers -->
-        <service id="tbbc_money.ratio_provider.yahoo_finance" class="%tbbc_money.ratio_provider.yahoo_finance.class%" public="true">
-        </service>
         <service id="tbbc_money.ratio_provider.google" class="%tbbc_money.ratio_provider.google.class%" public="true">
         </service>
         <service id="tbbc_money.ratio_provider.ecb" class="%tbbc_money.ratio_provider.ecb.class%">


### PR DESCRIPTION
Both classes don't exist in the repository but they were referenced in `services.xml` file.

This makes running the `lint:container` command fail within a Symfony 5/6 project:

```
php bin/console lint:container

In AbstractRecursivePass.php line 176:

  Invalid service "tbbc_money.ratio_provider.yahoo_finance": class "Tbbc\MoneyBundle\Pair\RatioProvider\YahooFinanceRatioProvider" does not exist.


lint:container
```