### PR TITLE
Use the Doctrine native column types (int)

### DIFF
--- a/src/Entity/DoctrineStorageRatio.php
+++ b/src/Entity/DoctrineStorageRatio.php
@@ -9,7 +9,7 @@ namespace Tbbc\MoneyBundle\Entity;
  */
 class DoctrineStorageRatio
 {
-    private mixed $id = null;
+    private ?int $id = null;
 
     public function __construct(private ?string $currencyCode = null, private ?float $ratio = null)
     {

--- a/src/Entity/RatioHistory.php
+++ b/src/Entity/RatioHistory.php
@@ -12,7 +12,7 @@ use DateTimeInterface;
  */
 class RatioHistory
 {
-    protected mixed $id = null;
+    protected ?int $id = null;
     protected string $referenceCurrencyCode = '';
     protected string $currencyCode = '';
     protected float $ratio = 0;


### PR DESCRIPTION
Error:
```
console doctrine:schema:validate --em=default

Mapping
-------

 [FAIL] The entity-class Tbbc\MoneyBundle\Entity\DoctrineStorageRatio mapping is invalid:
 * The field 'Tbbc\MoneyBundle\Entity\DoctrineStorageRatio#id' has the property type 'mixed' that differs from the metadata field type 'int' returned by the 'integer' DBAL type.


 [FAIL] The entity-class Tbbc\MoneyBundle\Entity\RatioHistory mapping is invalid:
 * The field 'Tbbc\MoneyBundle\Entity\RatioHistory#id' has the property type 'mixed' that differs from the metadata field type 'int' returned by the 'integer' DBAL type.

```