### PR TITLE
docs: add infos to run tests local with mongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,12 @@ Contributing
 1. Take a look at the [list of issues](https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/issues).
 2. Fork
 3. Write a test (for either new feature or bug)
-4. Make a PR
+4. Optional: Start MongoDB in Docker for local testing
+```bash
+docker run --name "money-bundle-mongo-db-test" -p 27017:27017 -d mongo:latest
+```
+5. Make a PR
+
 
 Authors
 -------

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     },
     "suggest": {
         "doctrine/doctrine-bundle": "~2.11",
+        "doctrine/mongodb-odm-bundle": "For usage with MongoDB",
         "doctrine/orm": "~2.17",
         "florianv/exchanger": "Exchanger is a PHP framework to work with currency exchange rates from various services."
     },


### PR DESCRIPTION
i could not run the mongoDB tests local. With this command it works.

Info: It will not work if the port 27017 is already used.

