### PR TITLE
feat: remove support for "moneyphp/money" < 4.5

### DIFF
--- a/change-log-6.0-and-versions.md
+++ b/change-log-6.0-and-versions.md
@@ -1,7 +1,7 @@
 Versions from 6.0
 -----------------
 
-### TBD : updates for 6.0.0 version
+### Not yet released!
 
 **New features**
 - Bumped minimum PHP version to PHP ^8.1
@@ -15,4 +15,4 @@ Versions from 6.0
 - Drop PHPUnit 9 support
 - bump dev dependencies
 - Migrate phpUnit config to version 10.
-
+- Remove support for moneyphp/money < 4.5 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-curl" : "*",
         "ext-intl": "*",
         "ext-simplexml": "*",
-        "moneyphp/money": "^3.0|^4.0",
+        "moneyphp/money": "^4.5",
         "symfony/form": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "symfony/console": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/issues/171

I need to take a deeper look, if there are tests or bc layers that can be removed.
https://github.com/moneyphp/money/blob/master/CHANGELOG.md#400---2021-05-17