### PR TITLE
feat: improve currency type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,76 +1,76 @@
 {
-  "name": "tbbc/money-bundle",
-  "type": "symfony-bundle",
-  "description": "This is a Symfony bundle that integrates moneyphp/money library (Fowler pattern): https://github.com/moneyphp/money.",
-  "keywords": ["money", "currency", "fowler", "conversion", "symfony"],
-  "homepage": "https://github.com/TheBigBrainsCompany/TbbcMoneyBundle",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Philippe Le Van",
-      "homepage": "https://twitter.com/plv"
+    "name": "tbbc/money-bundle",
+    "type": "symfony-bundle",
+    "description": "This is a Symfony bundle that integrates moneyphp/money library (Fowler pattern): https://github.com/moneyphp/money.",
+    "keywords": ["money", "currency", "fowler", "conversion", "symfony"],
+    "homepage": "https://github.com/TheBigBrainsCompany/TbbcMoneyBundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Philippe Le Van",
+            "homepage": "https://twitter.com/plv"
+        },
+        {
+            "name": "Sebastien Lefebvre"
+        },
+        {
+            "name": "Martin Aarhof"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "ext-curl" : "*",
+        "ext-intl": "*",
+        "ext-simplexml": "*",
+        "moneyphp/money": "^4.5",
+        "symfony/form": "^5.4|^6.0|^7.0",
+        "symfony/twig-bundle": "^5.4|^6.0|^7.0",
+        "symfony/console": "^5.4|^6.0|^7.0",
+        "symfony/dom-crawler": "^5.4|^6.0|^7.0",
+        "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+        "symfony/http-client": "^5.4|^6.0|^7.0",
+        "symfony/intl": "^5.4|^6.0|^7.0"
     },
-    {
-      "name": "Sebastien Lefebvre"
+    "autoload": {
+        "psr-4": {
+            "Tbbc\\MoneyBundle\\": "src"
+        }
     },
-    {
-      "name": "Martin Aarhof"
+    "require-dev": {
+        "ext-sqlite3": "*",
+        "symfony/browser-kit": "^5.4|^6.0|^7.0",
+        "doctrine/doctrine-bundle": "^2.11",
+        "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
+        "doctrine/orm": "^2.11",
+        "florianv/exchanger": "^2.8.1",
+        "php-http/message": "^1.0",
+        "php-http/guzzle7-adapter": "^1.0",
+        "vimeo/psalm": "^5.20",
+        "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
+        "phpunit/phpunit": "^10.5.9",
+        "symfony/yaml": "^5.4|^6.0|^7.0",
+        "http-interop/http-factory-guzzle": "^1.2"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tbbc\\MoneyBundle\\Tests\\": "Tests"
+        }
+    },
+    "scripts": {
+        "fix": [
+            "vendor/bin/psalm",
+            "vendor/bin/phpunit --coverage-text --coverage-html=.build"
+        ]
+    },
+    "suggest": {
+        "doctrine/doctrine-bundle": "~2.11",
+        "doctrine/mongodb-odm-bundle": "For usage with MongoDB",
+        "doctrine/orm": "~2.17",
+        "florianv/exchanger": "Exchanger is a PHP framework to work with currency exchange rates from various services."
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
-  ],
-  "require": {
-    "php": "^8.1",
-    "ext-curl" : "*",
-    "ext-intl": "*",
-    "ext-simplexml": "*",
-    "moneyphp/money": "^4.5",
-    "symfony/form": "^5.4|^6.0|^7.0",
-    "symfony/twig-bundle": "^5.4|^6.0|^7.0",
-    "symfony/console": "^5.4|^6.0|^7.0",
-    "symfony/dom-crawler": "^5.4|^6.0|^7.0",
-    "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-    "symfony/http-client": "^5.4|^6.0|^7.0",
-    "symfony/intl": "^5.4|^6.0|^7.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Tbbc\\MoneyBundle\\": "src"
-    }
-  },
-  "require-dev": {
-    "ext-sqlite3": "*",
-    "symfony/browser-kit": "^5.4|^6.0|^7.0",
-    "doctrine/doctrine-bundle": "^2.11",
-    "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
-    "doctrine/orm": "^2.11",
-    "florianv/exchanger": "^2.8.1",
-    "php-http/message": "^1.0",
-    "php-http/guzzle7-adapter": "^1.0",
-    "vimeo/psalm": "^5.20",
-    "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
-    "phpunit/phpunit": "^10.5.9",
-    "symfony/yaml": "^5.4|^6.0|^7.0",
-    "http-interop/http-factory-guzzle": "^1.2"
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Tbbc\\MoneyBundle\\Tests\\": "Tests"
-    }
-  },
-  "scripts": {
-    "fix": [
-      "vendor/bin/psalm",
-      "vendor/bin/phpunit --coverage-text --coverage-html=.build"
-    ]
-  },
-  "suggest": {
-    "doctrine/doctrine-bundle": "~2.11",
-    "doctrine/mongodb-odm-bundle": "For usage with MongoDB",
-    "doctrine/orm": "~2.17",
-    "florianv/exchanger": "Exchanger is a PHP framework to work with currency exchange rates from various services."
-  },
-  "config": {
-    "allow-plugins": {
-      "php-http/discovery": true
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,76 @@
 {
-    "name": "tbbc/money-bundle",
-    "type": "symfony-bundle",
-    "description": "This is a Symfony bundle that integrates moneyphp/money library (Fowler pattern): https://github.com/moneyphp/money.",
-    "keywords": ["money", "currency", "fowler", "conversion", "symfony"],
-    "homepage": "https://github.com/TheBigBrainsCompany/TbbcMoneyBundle",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Philippe Le Van",
-            "homepage": "https://twitter.com/plv"
-        },
-        {
-            "name": "Sebastien Lefebvre"
-        },
-        {
-            "name": "Martin Aarhof"
-        }
-    ],
-    "require": {
-        "php": "^8.1",
-        "ext-curl" : "*",
-        "ext-intl": "*",
-        "ext-simplexml": "*",
-        "moneyphp/money": "^4.5",
-        "symfony/form": "^5.4|^6.0|^7.0",
-        "symfony/twig-bundle": "^5.4|^6.0|^7.0",
-        "symfony/console": "^5.4|^6.0|^7.0",
-        "symfony/dom-crawler": "^5.4|^6.0|^7.0",
-        "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-        "symfony/http-client": "^5.4|^6.0|^7.0"
+  "name": "tbbc/money-bundle",
+  "type": "symfony-bundle",
+  "description": "This is a Symfony bundle that integrates moneyphp/money library (Fowler pattern): https://github.com/moneyphp/money.",
+  "keywords": ["money", "currency", "fowler", "conversion", "symfony"],
+  "homepage": "https://github.com/TheBigBrainsCompany/TbbcMoneyBundle",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Philippe Le Van",
+      "homepage": "https://twitter.com/plv"
     },
-    "autoload": {
-        "psr-4": {
-            "Tbbc\\MoneyBundle\\": "src"
-        }
+    {
+      "name": "Sebastien Lefebvre"
     },
-    "require-dev": {
-        "ext-sqlite3": "*",
-        "symfony/browser-kit": "^5.4|^6.0|^7.0",
-        "doctrine/doctrine-bundle": "^2.11",
-        "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
-        "doctrine/orm": "^2.11",
-        "florianv/exchanger": "^2.8.1",
-        "php-http/message": "^1.0",
-        "php-http/guzzle7-adapter": "^1.0",
-        "vimeo/psalm": "^5.20",
-        "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
-        "phpunit/phpunit": "^10.5.9",
-        "symfony/yaml": "^5.4|^6.0|^7.0",
-        "http-interop/http-factory-guzzle": "^1.2"
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tbbc\\MoneyBundle\\Tests\\": "Tests"
-        }
-    },
-    "scripts": {
-        "fix": [
-            "vendor/bin/psalm",
-            "vendor/bin/phpunit --coverage-text --coverage-html=.build"
-        ]
-    },
-    "suggest": {
-        "doctrine/doctrine-bundle": "~2.11",
-        "doctrine/mongodb-odm-bundle": "For usage with MongoDB",
-        "doctrine/orm": "~2.17",
-        "florianv/exchanger": "Exchanger is a PHP framework to work with currency exchange rates from various services."
-    },
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true
-        }
+    {
+      "name": "Martin Aarhof"
     }
+  ],
+  "require": {
+    "php": "^8.1",
+    "ext-curl" : "*",
+    "ext-intl": "*",
+    "ext-simplexml": "*",
+    "moneyphp/money": "^4.5",
+    "symfony/form": "^5.4|^6.0|^7.0",
+    "symfony/twig-bundle": "^5.4|^6.0|^7.0",
+    "symfony/console": "^5.4|^6.0|^7.0",
+    "symfony/dom-crawler": "^5.4|^6.0|^7.0",
+    "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+    "symfony/http-client": "^5.4|^6.0|^7.0",
+    "symfony/intl": "^5.4|^6.0|^7.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Tbbc\\MoneyBundle\\": "src"
+    }
+  },
+  "require-dev": {
+    "ext-sqlite3": "*",
+    "symfony/browser-kit": "^5.4|^6.0|^7.0",
+    "doctrine/doctrine-bundle": "^2.11",
+    "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
+    "doctrine/orm": "^2.11",
+    "florianv/exchanger": "^2.8.1",
+    "php-http/message": "^1.0",
+    "php-http/guzzle7-adapter": "^1.0",
+    "vimeo/psalm": "^5.20",
+    "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
+    "phpunit/phpunit": "^10.5.9",
+    "symfony/yaml": "^5.4|^6.0|^7.0",
+    "http-interop/http-factory-guzzle": "^1.2"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tbbc\\MoneyBundle\\Tests\\": "Tests"
+    }
+  },
+  "scripts": {
+    "fix": [
+      "vendor/bin/psalm",
+      "vendor/bin/phpunit --coverage-text --coverage-html=.build"
+    ]
+  },
+  "suggest": {
+    "doctrine/doctrine-bundle": "~2.11",
+    "doctrine/mongodb-odm-bundle": "For usage with MongoDB",
+    "doctrine/orm": "~2.17",
+    "florianv/exchanger": "Exchanger is a PHP framework to work with currency exchange rates from various services."
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
+  }
 }

--- a/src/Form/Type/CurrencyType.php
+++ b/src/Form/Type/CurrencyType.php
@@ -7,6 +7,7 @@ namespace Tbbc\MoneyBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Intl\Currencies;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\DataTransformer\CurrencyToArrayTransformer;
 
@@ -36,7 +37,12 @@ class CurrencyType extends AbstractType
     {
         $choiceList = [];
         foreach ($options['currency_choices'] as $currencyCode) {
-            $choiceList[$currencyCode] = $currencyCode;
+
+            if($options['currency_choices_label_format']==1) {
+                $choiceList[$currencyCode . ' - '.Currencies::getName($currencyCode)] = $currencyCode;
+            } else {
+                $choiceList[$currencyCode] = $currencyCode;
+            }
         }
 
         $builder->add('tbbc_name', ChoiceType::class, array_merge([
@@ -57,9 +63,11 @@ class CurrencyType extends AbstractType
             'reference_currency' => $this->referenceCurrencyCode,
             'currency_choices' => $this->currencyCodeList,
             'currency_options' => [],
+            'currency_choices_label_format' => 0,
         ]);
         $resolver->setAllowedTypes('reference_currency', 'string');
         $resolver->setAllowedTypes('currency_choices', 'array');
+        $resolver->setAllowedTypes('currency_choices_label_format', 'int');
         $resolver->setAllowedValues('reference_currency', $this->currencyCodeList);
         $resolver->setAllowedTypes('currency_options', 'array');
     }


### PR DESCRIPTION
I am not sure what is the best way to implement it.
With this implementation it is an opt-in for the longer labels.

Default
<img width="1091" alt="before-only-code" src="https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/assets/7104259/6903fb47-71a9-4969-b03a-27de5783abc0">

With local currency name
<img width="1092" alt="after-locale-name" src="https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/assets/7104259/9f60cfab-1af5-4cdc-86d5-68ef43ce6d74">

Usage:
->add('currency',     CurrencyType::class, ['label' => 'foo', 'currency_choices_label_format' => 1])
