### PR TITLE
ORM service is optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "ext-sqlite3": "*",
         "symfony/browser-kit": "^5.4|^6.0|^7.0",
         "doctrine/doctrine-bundle": "^2.12",
+        "doctrine/mongodb-odm": "<2.8",
         "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
         "doctrine/orm": "^2.19.3|^3.0",
         "florianv/exchanger": "^2.8.1",

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -30,7 +30,6 @@
         <service id="%tbbc_money.pair_manager_interface.class%" alias="tbbc_money.pair_manager" public="false">
         </service>
         <service id="tbbc_money.pair_history_manager" class="%tbbc_money.pair_history_manager.class%" public="true">
-            <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument>%tbbc_money.reference_currency%</argument>
         </service>
         <service id="%tbbc_money.pair_history_manager_interface.class%" alias="tbbc_money.pair_history_manager" public="false">


### PR DESCRIPTION
When using pair history ORM is now optional not required.

Removing this should allow MongoDB users to use pair history without having the ORM package installed.