### PR TITLE
Relax mongodb-odm constraints after listSearchIndexes exception resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-sqlite3": "*",
         "symfony/browser-kit": "^5.4|^6.0|^7.0",
         "doctrine/doctrine-bundle": "^2.12",
-        "doctrine/mongodb-odm": "<2.8",
+        "doctrine/mongodb-odm": "<2.8|^2.8.2",
         "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
         "doctrine/orm": "^2.19.3|^3.0",
         "florianv/exchanger": "^2.8.1",


### PR DESCRIPTION
The listSearchIndexes exception that affected mongodb-odm v2.8.0 (and v2.8.1) has been resolved in v2.8.2, so we can relax or remove the constraints now.