### PR TITLE
Remove deprecated twig spaceless filter

### DIFF
--- a/src/Resources/views/Form/fields.html.twig
+++ b/src/Resources/views/Form/fields.html.twig
@@ -1,10 +1,10 @@
 {% block tbbc_money_widget %}
     {% for child in form %}
-        {{ form_widget(child) | spaceless }}
+        {{ form_widget(child) }}
     {% endfor %}
 {% endblock %}
 {% block tbbc_currency_widget %}
     {% for child in form %}
-        {{ form_widget(child) | spaceless }}
+        {{ form_widget(child) }}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
As of Twig 3.12 the spaceless filter has been deprecated.

https://twig.symfony.com/doc/3.x/filters/spaceless.html