### PR TITLE
fix: deprecation for fgetcsv in CsvStorage.php

### DIFF
--- a/src/Pair/Storage/CsvStorage.php
+++ b/src/Pair/Storage/CsvStorage.php
@@ -45,7 +45,8 @@ class CsvStorage implements StorageInterface
         }
         $row = 1;
         $this->ratioList = [];
-        while (($data = fgetcsv($handle, 1000, ';')) !== false) {
+
+        while (($data = fgetcsv($handle, 1000, ';', "\"", "\\")) !== false) {
             // extract data from CSV line
             if (2 !== count($data)) {
                 throw new MoneyException('error in ratioFileName '.$this->ratioFileName.' on line '.$row.', invalid argument count');


### PR DESCRIPTION
https://www.php.net/manual/en/function.fgetcsv.php

Please see warning for parameter `escape`

Another solution would be to set it to `''`