### PR TITLE
feat: Add console command tags to ratio commands

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -60,11 +60,20 @@ return static function (ContainerConfigurator $configurator): void {
         ->arg('$decimals', '%tbbc_money.decimals%');
 
     $services->set(RatioFetchCommand::class)
-        ->arg('$pairManager', service(PairManagerInterface::class));
+        ->arg('$pairManager', service(PairManagerInterface::class))
+        ->tag('console.command', [
+            'command' => 'tbbc:money:ratio-fetch',
+        ]);
 
     $services->set(RatioListCommand::class)
-        ->arg('$pairManager', service(PairManagerInterface::class));
+        ->arg('$pairManager', service(PairManagerInterface::class))
+        ->tag('console.command', [
+            'command' => 'tbbc:money:ratio-list',
+        ]);
 
     $services->set(RatioSaveCommand::class)
-        ->arg('$pairManager', service(PairManagerInterface::class));
+        ->arg('$pairManager', service(PairManagerInterface::class))
+        ->tag('console.command', [
+            'command' => 'tbbc:money:ratio-save',
+        ])
 };


### PR DESCRIPTION
@johanwilfer 
is there a specific reason the tag for command was removed?
https://github.com/TheBigBrainsCompany/TbbcMoneyBundle/commit/ad4bec4d00da4abdda704078418f7c7b778d8dd7#diff-e6158a37fd9d16c7ed52aba12c01e51579b676404e20ea06ce751598fe2ec622

Or as alternative add (see the command in the bottom of this image)
#[AsCommand(name: 'tbbc:money:ratio-fetch', description: 'tbbc:money:ratio-fetch')]
<img width="929" height="387" alt="Name difference" src="https://github.com/user-attachments/assets/50615d6e-c357-475c-9766-3227f1fe970b" />
I guess this is the best solution to keep names the same.
I will create a PR.

I used to call `tbbc:money:ratio-fetch` and use symfony 8 in a cronjob. Via https://github.com/Dukecity/CommandSchedulerBundle
But this is not possible anymore, because the commands are not listed anymore.

